### PR TITLE
Implemented Inlay Parameter exclude list

### DIFF
--- a/src/main/resources/LuaBundle.properties
+++ b/src/main/resources/LuaBundle.properties
@@ -43,3 +43,14 @@ ui.settings.strict_nil_checks=Strict nil checks
 ui.settings.unknown_indexable=Unknown type (any) is indexable
 ui.settings.unknown_callable=Unknown type (any) is callable
 ui.settings.require_like_function_names=&Require-like function names:
+ui.settings.require_like_function_names=&Require-like function names:
+inlay.hints.blacklist.pattern.explanation=<html> \
+ To disable hints for a function use the appropriate pattern: \
+ <p> \
+     <code><b>math.*<b></code><br> \
+     <code><b>*.insert*<b></code><br> \
+     <code>(*_)</code> - single parameter function where the parameter name ends with <i>_</i><br /> \
+     <code>(key, value)</code> - functions with parameters <i>key</i> and <i>value</i><br /> \
+     <code>*.put(key, value)</code> - <i>put</i> functions with <i>key</i> and <i>value</i> parameters \
+ </p> \
+ </html> 


### PR DESCRIPTION
This adds the 'Exclude list...' option to the Inlay Param configuration which opens the list dialog
In this dialog you can enter some exceptions for when not to show Inlay Params:

e.g.
*.insert* will cancel Inlay Params on all insert methods
math.* will cancel Inlay Params on all math.* methods