### PR TITLE
Implemented SPACE_INSIDE_INLINE_TABLE

### DIFF
--- a/src/main/java/com/tang/intellij/lua/editor/formatter/LuaCodeStyleSettings.java
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/LuaCodeStyleSettings.java
@@ -28,6 +28,8 @@ public class LuaCodeStyleSettings extends CustomCodeStyleSettings {
 
     public boolean SPACE_AFTER_TABLE_FIELD_SEP = true;
 
+    public boolean SPACE_INSIDE_INLINE_TABLE = true;
+
     public boolean ALIGN_TABLE_FIELD_ASSIGN = false;
 
     LuaCodeStyleSettings(CodeStyleSettings container) {

--- a/src/main/java/com/tang/intellij/lua/editor/formatter/LuaFormattingModelBuilder.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/LuaFormattingModelBuilder.kt
@@ -59,8 +59,8 @@ class LuaFormattingModelBuilder : FormattingModelBuilder {
                 .around(COLON).none()
                 .before(COMMA).spaces(if (commonSettings.SPACE_BEFORE_COMMA) 1 else 0)
                 .after(COMMA).spaces(if (commonSettings.SPACE_AFTER_COMMA) 1 else 0) //,<SPACE>
-                .between(LCURLY, TABLE_FIELD).spaces(1) // {<SPACE>1, 2 }
-                .between(TABLE_FIELD, RCURLY).spaces(1) // { 1, 2<SPACE>}
+                .between(LCURLY, TABLE_FIELD).spaces(if (luaCodeStyleSettings.SPACE_INSIDE_INLINE_TABLE) 1 else 0) // {<SPACE>1, 2 }
+                .between(TABLE_FIELD, RCURLY).spaces(if (luaCodeStyleSettings.SPACE_INSIDE_INLINE_TABLE) 1 else 0) // { 1, 2<SPACE>}
                 .before(TABLE_FIELD_SEP).none() // { 1<SPACE>, 2 }
                 .after(TABLE_FIELD_SEP).spaces(if (luaCodeStyleSettings.SPACE_AFTER_TABLE_FIELD_SEP) 1 else 0) // { 1,<SPACE>2 }
                 .before(BLOCK).blankLines(0)

--- a/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
@@ -50,6 +50,7 @@ class LuaLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider()
         when (settingsType) {
             LanguageCodeStyleSettingsProvider.SettingsType.SPACING_SETTINGS -> {
                 consumer.showCustomOption(LuaCodeStyleSettings::class.java, "SPACE_AFTER_TABLE_FIELD_SEP", "After field sep", SPACES_OTHER)
+                consumer.showCustomOption(LuaCodeStyleSettings::class.java, "SPACE_INSIDE_INLINE_TABLE", "Inside inline table", SPACES_OTHER)
                 consumer.showStandardOptions("SPACE_AROUND_ASSIGNMENT_OPERATORS",
                         "SPACE_BEFORE_COMMA",
                         "SPACE_AFTER_COMMA")

--- a/src/main/resources/codeStyle/preview/preview.lua.template
+++ b/src/main/resources/codeStyle/preview/preview.lua.template
@@ -1,3 +1,4 @@
+local inlineEmmy = { name = "Emmy", age = 7, longLongProperty = 123 }
 local emmy = {
     name = "Emmy",
     age = 7,


### PR DESCRIPTION
configures wether you'd like to have a space between the curly brackets and a table field, e.g. `{ field = 1 }` vs `{field = 1} `(previously spaces were always added)