### PR TITLE
iterate over all ILuaTypeInfer extensions

### DIFF
--- a/src/main/java/com/tang/intellij/lua/ext/ILuaTypeInfer.kt
+++ b/src/main/java/com/tang/intellij/lua/ext/ILuaTypeInfer.kt
@@ -29,7 +29,8 @@ interface ILuaTypeInfer {
         fun infer(context: SearchContext, target: LuaPsiTypeGuessable): ITy? {
             for (typeInfer in EP_NAME.extensionList) {
                 ProgressManager.checkCanceled()
-                return typeInfer.inferType(context, target)
+                var inferType = typeInfer.inferType(context, target)
+                if (inferType != null) return inferType
             }
             return null
         }


### PR DESCRIPTION
This is a quick fix/workaround for #110 

I decided against trying to implement the `unknown` type. I don't have enough experience with your code to do such a overwhole :(

This will allow me to run my detection code before your's is run and if i don't find anything, i can just return `null` to make the original guessing do it's work.

If you change the design of this extension, i will just change my code for it.
It seems like i am the only person that has EmmyLua or Luanalysis as dependency.
https://plugins.jetbrains.com/plugins/list/?build=IC-212.*