### PR TITLE
Corrected definitions for string.pack and string.unpack

### DIFF
--- a/src/main/resources/std/Lua53/string.def.lua
+++ b/src/main/resources/std/Lua53/string.def.lua
@@ -244,10 +244,10 @@ function string.match(s, pattern, init) end
 --- Returns a binary string containing the values `v1`, `v2`, etc. packed (that
 --- is, serialized in binary form) according to the format string `fmt`.
 ---@param fmt string
----@param v1 string
----@param v2 string
+---@param v1 number
+---@vararg number
 ---@return string
-function string.pack(fmt, v1, v2, ...) end
+function string.pack(fmt, v1, ...) end
 
 ---
 --- Returns the size of a string resulting from `string.pack` with the given
@@ -302,11 +302,11 @@ function string.sub(s, i, j) end
 --- `fmt`. An optional `pos` marks where to start reading in `s` (default is 1).
 --- After the read values, this function also returns the index of the first
 --- unread byte in `s`.
----@overload fun(fmt:string, s:string):string
+---@overload fun(fmt:string, s:string):number...
 ---@param fmt string
 ---@param s string
 ---@param pos number
----@return string
+---@return number...
 function string.unpack(fmt, s, pos) end
 
 ---

--- a/src/main/resources/std/Lua54/string.def.lua
+++ b/src/main/resources/std/Lua54/string.def.lua
@@ -244,10 +244,10 @@ function string.match(s, pattern, init) end
 --- Returns a binary string containing the values `v1`, `v2`, etc. packed (that
 --- is, serialized in binary form) according to the format string `fmt`.
 ---@param fmt string
----@param v1 string
----@param v2 string
+---@param v1 number
+---@vararg number
 ---@return string
-function string.pack(fmt, v1, v2, ...) end
+function string.pack(fmt, v1, ...) end
 
 ---
 --- Returns the size of a string resulting from `string.pack` with the given
@@ -302,11 +302,11 @@ function string.sub(s, i, j) end
 --- `fmt`. An optional `pos` marks where to start reading in `s` (default is 1).
 --- After the read values, this function also returns the index of the first
 --- unread byte in `s`.
----@overload fun(fmt:string, s:string):string
+---@overload fun(fmt:string, s:string):number...
 ---@param fmt string
 ---@param s string
 ---@param pos number
----@return string
+---@return number...
 function string.unpack(fmt, s, pos) end
 
 ---


### PR DESCRIPTION
Strings as input to `string.pack` are wrong, and `string.unpack` also doesn't return strings.